### PR TITLE
Fix type hinting

### DIFF
--- a/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
+++ b/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
@@ -4,7 +4,7 @@ import sys
 import random
 from datetime import datetime
 import os
-from typing import Dict
+from typing import Dict, List
 from dataclasses import dataclass
 from hmac import HMAC
 from urllib.request import urlopen, Request
@@ -248,7 +248,7 @@ class TencentCloudClient:
         }
         return self.mk_post_req("DescribeDomain", payload)
 
-    def describe_record_list(self, domain: str) -> list[Dict]:
+    def describe_record_list(self, domain: str) -> List[Dict]:
         offset = 0
         payload = {
             "Domain": domain,


### PR DESCRIPTION
The plugin is actually not working with Python 3.8 due to a tiny incorrect type hinting:

```
$ certbot version
An unexpected error occurred:
TypeError: 'type' object is not subscriptable
Ask for help or search for solutions at https://community.letsencrypt.org. See the logfile /tmp/certbot-log-qcjwa8mf/log or re-run Certbot with -v for more details.
$
```

This is fixed by using `List` instead of `list`.

Note that this is not required for Python 3.9 and newer. See [PEP 585](https://peps.python.org/pep-0585/) for more info.