### PR TITLE
Remove the zope.interface dependency

### DIFF
--- a/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
+++ b/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
@@ -9,13 +9,10 @@ from dataclasses import dataclass
 from hmac import HMAC
 from urllib.request import urlopen, Request
 
-import zope.interface
-from certbot import errors, interfaces
+from certbot import errors
 from certbot.plugins import dns_common
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for TencentCloud
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'certbot',
-        'zope.interface',
+        'certbot>=1.18.0',
     ],
     classifiers=[
         'Environment :: Plugins',


### PR DESCRIPTION
The `zope.interface` mechanism was modified [since Certbot 1.18.0 in favor of abstract base classes](https://github.com/certbot/certbot/commit/979e21dcbf11665f7839628cfae62e28fd2683df) and was [deprecated in Certbot 1.19.0](https://github.com/certbot/certbot/commit/23e1e07139d1abc3a9ae6338991daba770141a0a).

It's no longer required nor useful.