### PR TITLE
fix: use UTC date in TC3-HMAC-SHA256 signature

### DIFF
--- a/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
+++ b/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
@@ -2,8 +2,7 @@ import json
 import hashlib
 import sys
 import random
-import time
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 from typing import Dict, List
 from dataclasses import dataclass
@@ -168,8 +167,9 @@ class TencentCloudClient:
         self.debug = debug
 
     def _mk_post_sign_v3(self, payload: Dict) -> Dict:
-        now_timestamp = int(time.time())
-        date = datetime.utcfromtimestamp(now_timestamp).strftime("%Y-%m-%d")
+        now = datetime.now(timezone.utc)
+        now_timestamp = int(now.timestamp())
+        date = now.strftime("%Y-%m-%d")
         headers = {
             "Something-Random": random.getrandbits(64),
             "Content-Type": "application/json; charset=utf-8",

--- a/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
+++ b/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
@@ -2,6 +2,7 @@ import json
 import hashlib
 import sys
 import random
+import time
 from datetime import datetime
 import os
 from typing import Dict, List
@@ -167,9 +168,8 @@ class TencentCloudClient:
         self.debug = debug
 
     def _mk_post_sign_v3(self, payload: Dict) -> Dict:
-        now = datetime.now()
-        now_timestamp = int(now.timestamp())
-        date = now.strftime("%Y-%m-%d")
+        now_timestamp = int(time.time())
+        date = datetime.utcfromtimestamp(now_timestamp).strftime("%Y-%m-%d")
         headers = {
             "Something-Random": random.getrandbits(64),
             "Content-Type": "application/json; charset=utf-8",


### PR DESCRIPTION
## Problem

The `_mk_post_sign_v3` method uses `datetime.now()` to derive the date string for the TC3-HMAC-SHA256 credential scope. While `datetime.timestamp()` correctly returns a UTC epoch, `strftime("%Y-%m-%d")` produces the **local** date.

In time zones with a positive UTC offset (e.g. UTC+8), the local date rolls over to the next day before UTC does. During that window (00:00–08:00 CST), the credential scope date and the timestamp date disagree, causing Tencent Cloud to reject the signature with `AuthFailure.SignatureFailure`.

### Reproduction

On a server in UTC+8, any API call made between 00:00 and 08:00 local time fails:

```
APIException: {'Code': 'AuthFailure.SignatureFailure',
'Message': 'The provided credentials could not be validated. Please check your signature is correct.'}
```

The same call succeeds after 08:00, when local and UTC dates align again.

## Fix

Use `time.time()` for the UTC epoch and `datetime.utcfromtimestamp()` to derive a consistent UTC date string. This ensures the credential scope date always matches the timestamp, regardless of the server's time zone.