### PR TITLE
fix: keep duplicate validation cleanup records separate

### DIFF
--- a/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
+++ b/certbot_dns_tencentcloud/certbot_tencentcloud_plugins.py
@@ -128,7 +128,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
         sub_domain = validation_name[: -(len(base_domain) + 1)]
         r = client.create_record(base_domain, sub_domain, "TXT", validation)
-        self.cleanup_maps[validation_name] = (base_domain, r["RecordId"])
+        self.cleanup_maps[(validation_name, validation)] = (base_domain, r["RecordId"])
 
     def _cleanup(self, domain, validation_name, validation):
         if self.conf("debug"):
@@ -138,8 +138,9 @@ class Authenticator(dns_common.DNSAuthenticator):
             self.secret_key,
             self.conf("debug"),
         )
-        if validation_name in self.cleanup_maps:
-            base_domain, record_id = self.cleanup_maps[validation_name]
+        cleanup_key = (validation_name, validation)
+        if cleanup_key in self.cleanup_maps:
+            base_domain, record_id = self.cleanup_maps.pop(cleanup_key)
             client.delete_record(base_domain, record_id)
         else:
             print("record id not found during cleanup, cleanup probably failed")

--- a/tests/test_cleanup_records.py
+++ b/tests/test_cleanup_records.py
@@ -1,0 +1,115 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+def import_plugin_with_certbot_stubs():
+    errors_module = types.ModuleType("certbot.errors")
+
+    class PluginError(Exception):
+        pass
+
+    errors_module.PluginError = PluginError
+
+    certbot_module = types.ModuleType("certbot")
+    certbot_module.errors = errors_module
+
+    plugins_module = types.ModuleType("certbot.plugins")
+    dns_common_module = types.ModuleType("certbot.plugins.dns_common")
+
+    class DNSAuthenticator:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    dns_common_module.DNSAuthenticator = DNSAuthenticator
+    plugins_module.dns_common = dns_common_module
+
+    sys.modules.setdefault("certbot", certbot_module)
+    sys.modules.setdefault("certbot.errors", errors_module)
+    sys.modules.setdefault("certbot.plugins", plugins_module)
+    sys.modules.setdefault("certbot.plugins.dns_common", dns_common_module)
+
+    return importlib.import_module(
+        "certbot_dns_tencentcloud.certbot_tencentcloud_plugins"
+    )
+
+
+plugin = import_plugin_with_certbot_stubs()
+
+
+class FakeTencentCloudClient:
+    created_records = []
+    deleted_records = []
+
+    def __init__(self, secret_id, secret_key, debug=False):
+        self.secret_id = secret_id
+        self.secret_key = secret_key
+        self.debug = debug
+
+    def create_record(self, domain, sub_domain, record_type, value):
+        record_id = len(self.created_records) + 100
+        self.created_records.append(
+            {
+                "domain": domain,
+                "sub_domain": sub_domain,
+                "record_type": record_type,
+                "value": value,
+                "record_id": record_id,
+            }
+        )
+        return {"RecordId": record_id}
+
+    def delete_record(self, domain, record_id):
+        self.deleted_records.append((domain, record_id))
+
+
+class AuthenticatorCleanupTest(unittest.TestCase):
+    def setUp(self):
+        self.original_client = plugin.TencentCloudClient
+        plugin.TencentCloudClient = FakeTencentCloudClient
+        FakeTencentCloudClient.created_records = []
+        FakeTencentCloudClient.deleted_records = []
+
+    def tearDown(self):
+        plugin.TencentCloudClient = self.original_client
+
+    def make_authenticator(self):
+        authenticator = plugin.Authenticator.__new__(plugin.Authenticator)
+        authenticator.secret_id = "secret-id"
+        authenticator.secret_key = "secret-key"
+        authenticator.cleanup_maps = {}
+        authenticator.conf = lambda option: False
+        authenticator.determine_base_domain = lambda domain: ("example.com", [])
+        return authenticator
+
+    def test_cleanup_tracks_duplicate_validation_names_independently(self):
+        authenticator = self.make_authenticator()
+        validation_name = "_acme-challenge.example.com"
+
+        authenticator._perform("example.com", validation_name, "first-validation")
+        authenticator._perform("example.com", validation_name, "second-validation")
+
+        self.assertEqual(
+            [
+                ("_acme-challenge", "first-validation", 100),
+                ("_acme-challenge", "second-validation", 101),
+            ],
+            [
+                (record["sub_domain"], record["value"], record["record_id"])
+                for record in FakeTencentCloudClient.created_records
+            ],
+        )
+
+        authenticator._cleanup("example.com", validation_name, "first-validation")
+        authenticator._cleanup("example.com", validation_name, "second-validation")
+
+        self.assertEqual(
+            [("example.com", 100), ("example.com", 101)],
+            FakeTencentCloudClient.deleted_records,
+        )
+        self.assertEqual({}, authenticator.cleanup_maps)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix cleanup tracking for certificate orders that produce multiple dns-01 challenges with the same validation name, such as requesting both `example.com` and `*.example.com` in one certificate.

## Problem

The current cleanup map is keyed only by `validation_name`:

```python
self.cleanup_maps[validation_name] = (base_domain, r["RecordId"])
```

For apex + wildcard requests, Certbot can create two TXT records at the same DNS name (`_acme-challenge.example.com`) with different validation values. The second `_perform()` overwrites the first record id. During cleanup, the plugin then either deletes the wrong/same record twice or leaves one TXT record behind.

This appears to be a regression of the scenario discussed in #2. The older fix added separate TXT records for overlapping challenges; this patch keeps the newer record-id based cleanup behavior but tracks duplicate validation names independently.

## Changes

- Key cleanup records by `(validation_name, validation)` instead of only `validation_name`.
- Pop cleanup entries once they are deleted.
- Add a standard-library `unittest` regression test for duplicate validation names.

## Verification

```bash
python3 -m unittest discover -s tests -v
```

